### PR TITLE
Fix action plan browser layer

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,9 @@ Changelog
 
 - Adapt the survey-view template to the latest Euphorie
   [ale-rt]
+- Fix for prioritiy risks being displayed though they were answered N/A.
+  https://github.com/syslabcom/scrum/issues/1020
+  [reinhardt]
 
 9.0.4 (2023-02-28)
 ------------------

--- a/src/tno/euphorie/client/browser/configure.zcml
+++ b/src/tno/euphorie/client/browser/configure.zcml
@@ -39,7 +39,7 @@
           permission="euphorie.client.ViewSurvey"
           class="tno.euphorie.client.browser.session.ActionPlanView"
           template="templates/actionplan.pt"
-          layer="tno.euphorie.interfaces.ITnoContentSkinLayer"
+          layer="tno.euphorie.interfaces.ITnoClientSkinLayer"
           />
 
       <!-- Status -->


### PR DESCRIPTION
Fixes issue where priority risks are displayed in the action plan navigation even though they were answered with “not applicable”. This happened because the override had the wrong browser layer and was not used.

This bug has slipped in here: https://github.com/euphorie/tno.euphorie/commit/e59ceac9a6ab8445f6a97299f33966556f704465#diff-f16390d8f62095130ffd3175ae2ccbe4a8a1d31dea0584a6b88b9cb1c676b233R45

syslabcom/scrum#1020